### PR TITLE
Add fg_focus to fix error while opening menubar

### DIFF
--- a/awesome/powerarrowf/theme.lua
+++ b/awesome/powerarrowf/theme.lua
@@ -15,7 +15,9 @@ theme.bg_urgent     = "#3F3F3F"
 theme.bg_systray    = theme.bg_normal
 
 theme.fg_normal     = "#AAAAAA"
+theme.fg_focus      = "#0099CC"
 theme.fg_urgent     = "#3F3F3F"
+
 theme.border_width  = 1
 theme.border_normal = "#000000"
 theme.border_focus  = "#535d6c"


### PR DESCRIPTION
Without fg_focus, you will have an error set local variable 'color' to nil when pressing "Windows + P" to open menubar
